### PR TITLE
Updating adal-node to ^0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
     "@azure/ms-rest-js": "^2.0.4",
-    "adal-node": "^0.1.28"
+    "adal-node": "^0.2.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
I tested some of the credentials using adal-node locally. Nothing failed. Tests also pass.

I also checked adal-node's changelog and all of the changes from v0.1.x to v0.2.x seem safe.